### PR TITLE
Use `cljs-library` instead of `cljs-lib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This setup allows for interactive development and testing for ClojureScript
 libraries.
 
 The template will generate a stub for the `<project-name>.core` namespace under
-`src/<proejct-name>`, and test sources in the `env/dev/<project-name>/` folder.
+`src/<project-name>`, and test sources in the `env/dev/<project-name>/` folder.
 
 A test page is generated in the `env/dev<project-name>/test_page.cljs` file.
 This page will be loaded when `lein figwheel` is run.
@@ -16,7 +16,7 @@ This page will be loaded when `lein figwheel` is run.
 
 create a new library project
 
-    lein new cljs-lib mylib
+    lein new cljs-library mylib
 
 run in development mode:
 


### PR DESCRIPTION
Calling `lein new cljs-lib mylib` is failing with:

```
Failed to resolve version for cljs-lib:lein-template:jar:RELEASE: Could not find metadata cljs-lib:lein-template/maven-metadata.xml in local (/Users/retro/.m2/repository)
Failed to resolve version for cljs-lib:lein-template:jar:RELEASE: Could not find metadata cljs-lib:lein-template/maven-metadata.xml in local (/Users/retro/.m2/repository)
This could be due to a typo in :dependencies, file system permissions, or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.
Could not find template cljs-lib on the classpath.
```

Using `cljs-library` as a template works correctly